### PR TITLE
可以用automake配合python制作源码包

### DIFF
--- a/oh3c/Makefile.am
+++ b/oh3c/Makefile.am
@@ -1,6 +1,8 @@
 bin_SCRIPTS = oh3c
 oh3c:
-	echo "#!$(PYTHON) $(pkgpythondir)/oh3c.py" > $@
+	echo "#!/bin/sh"                       > $@
+	echo "python $(pkgpythondir)/oh3c.py" >> $@
+CLEANFILES = $(bin_SCRIPTS)
 
 python_PYTHON = $(NULL)
 pkgpython_PYTHON = $(NULL)

--- a/oh3c/Makefile.am
+++ b/oh3c/Makefile.am
@@ -1,0 +1,13 @@
+bin_SCRIPTS = oh3c
+oh3c:
+	echo "#!$(PYTHON) $(pkgpythondir)/oh3c.py" > $@
+
+python_PYTHON = $(NULL)
+pkgpython_PYTHON = $(NULL)
+pkgpython_PYTHON += oh3c.py
+pkgpython_PYTHON += __init__.py
+pkgpython_PYTHON += eapauth.py
+pkgpython_PYTHON += eappacket.py
+pkgpython_PYTHON += macmgr.py
+pkgpython_PYTHON += usermgr.py
+

--- a/oh3c/configure.ac
+++ b/oh3c/configure.ac
@@ -1,0 +1,9 @@
+dnl Run autoreconf --install to generate ./configure from this file
+AC_INIT([oh3c],[1.0])
+AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AM_PATH_PYTHON
+AC_CONFIG_FILES([
+	Makefile
+])
+AC_OUTPUT
+

--- a/oh3c/help
+++ b/oh3c/help
@@ -1,0 +1,12 @@
+#!/bin/sh
+echo "帮助您自动生成可发布的源码包..."
+
+echo "1、调用automake和autoconf等标准工具"
+autoreconf --install
+
+echo "2、调用./configure脚本自动完成各项检查"
+./configure
+
+echo "3、调用make工具生成tar.gz源代码压缩包"
+make dist --quiet
+ls *.tar.gz || ls *.tar.bz2


### PR DESCRIPTION
考虑使用automake的主要原因是利用automake提供configure配置脚本、make install安装命令、另外还有make dist命令自动生成标准格式的tar.gz源码包
